### PR TITLE
Fix cache/db フォルダは git の管理外に

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+cache
+db


### PR DESCRIPTION
ビルド中に生成される cache フォルダおよび db フォルダはそれぞれ一時ファイル／データベースバイナリであるため、 
git 管理外とするのが妥当です。そのため、 .gitignore に cache/db を追加する修正を行ったものです。
